### PR TITLE
fix: Remove setup and teardown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@inferable/monitor": "^0.0.6",
         "dotenv": "^16.4.5",
-        "inferable": "^0.8.0",
+        "inferable": "^0.10.0",
         "tsx": "^4.16.2",
         "winston": "^3.13.1",
         "zod": "^3.23.8"
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/inferable": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/inferable/-/inferable-0.8.0.tgz",
-      "integrity": "sha512-FI3HotKHngkilo5LYT3XkhAznVXzTo+iwYnA1ZK1OI7mEYf+iEzOcSMpjy5C/1a5rwhYNAKy7OmMGg+4hDukMQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/inferable/-/inferable-0.10.0.tgz",
+      "integrity": "sha512-60ZbvgyUkiMdPcwNKpEohowK58WpeJyEsQD5sESqbrwaxteMnWFx+aQsZzp0SNVBbr2ZS3nQAkYRIw4wpXmjlg==",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",
         "@aws-sdk/client-sqs": "^3.600.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@inferable/monitor": "^0.0.6",
     "dotenv": "^16.4.5",
-    "inferable": "^0.8.0",
+    "inferable": "^0.10.0",
     "tsx": "^4.16.2",
     "winston": "^3.13.1",
     "zod": "^3.23.8"

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,20 +20,17 @@ const integrationSchema = z.object({
   name: z.string(),
   version: z.string(),
   initialize: z.function().returns(z.promise(serviceSchema)),
-  setup: z.function().returns(z.promise(z.void())),
-  teardown: z.function().returns(z.promise(z.void())),
 });
-
 
 async function main() {
   const start = new Date();
 
   logger.info("Discovering services...");
 
-  const services = loadLocalServices()
+  const services = loadLocalServices();
 
   const integrations = Object.keys(
-    require("../package.json").dependencies ?? [],
+    require("../package.json").dependencies ?? []
   )
     .filter((k) => k.startsWith("@inferable/"))
     .map((k) => {
@@ -55,7 +52,7 @@ async function main() {
             name: k,
             version: l.version,
             errors: parsed.error.issues,
-          },
+          }
         );
 
         return null;
@@ -70,13 +67,13 @@ async function main() {
   });
 
   const integrationServices = await Promise.all(
-    integrations.map((i) => i.setup().then(() => i.initialize(inferable))),
+    integrations.map((i) => i.initialize(inferable))
   );
 
   const startables = [...services, ...integrationServices];
 
   const settled = await Promise.allSettled(
-    startables.map((service) => service.start()),
+    startables.map((service) => service.start())
   );
 
   logger.info("Starting services complete!", {
@@ -115,7 +112,7 @@ main().then(({ services, start }) => {
             status: "ok",
             pid: process.pid,
             services: services.map((s) => s.definition),
-          }),
+          })
         );
 
         return;
@@ -148,9 +145,11 @@ process.on("uncaughtException", (error) => {
   process.exit(1);
 });
 
-function loadLocalServices(): RegisteredService[] {
+function loadLocalServices() {
   if (!fs.existsSync(path.join(__dirname, "services"))) {
-    logger.info("No services directory found, skipping local service discovery");
+    logger.info(
+      "No services directory found, skipping local service discovery"
+    );
     return [];
   }
 
@@ -158,10 +157,9 @@ function loadLocalServices(): RegisteredService[] {
     .readdirSync(path.join(__dirname, "services"))
     .filter(
       (filename) =>
-        filename.endsWith(".service.ts") || filename.endsWith(".service.js"),
+        filename.endsWith(".service.ts") || filename.endsWith(".service.js")
     )
     .map((filename) => require(path.join(__dirname, "services", filename)));
-
 
   const nonServices = fs
     .readdirSync(path.join(__dirname, "services"))
@@ -172,7 +170,7 @@ function loadLocalServices(): RegisteredService[] {
       "Found non-service files in services directory. These will not be loaded.",
       {
         files: nonServices,
-      },
+      }
     );
   }
 
@@ -195,4 +193,3 @@ function loadLocalServices(): RegisteredService[] {
     .map((i) => i!)
     .filter(Boolean);
 }
-


### PR DESCRIPTION
- Remove `setup` and `teardown` since:
  - `setup` ceremony can be done within `initialize` anyway.
  - `teardown` is not guaranteed to run. Therefore, it should be up to the service to handle `process.on(...)` in a suitable way.